### PR TITLE
enhancement: add retry logic to fetchOgImage for rate limiting +semver: minor

### DIFF
--- a/Src/fetch-github-sites.php
+++ b/Src/fetch-github-sites.php
@@ -20,29 +20,56 @@ function fetchOgImage(string $owner, string $repo, string $cacheDir, bool $isCli
     $cachePath = $cacheDir . '/' . $filename;
 
     if (file_exists($cachePath)) {
-        if ($isCli) echo "  [cache] {$filename}\n";
+        if ($isCli) {
+            echo "  [cache] {$filename}\n";
+        }
         return $filename;
     }
 
-    $ch = curl_init("https://opengraph.githubassets.com/1/{$owner}/{$repo}");
-    curl_setopt_array($ch, [
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_FOLLOWLOCATION => true,
-        CURLOPT_TIMEOUT        => 15,
-        CURLOPT_USERAGENT      => 'ZeroCool-Portfolio',
-    ]);
+    $maxRetries = 3;
+    $retryDelay = 10;
 
-    $data     = curl_exec($ch);
-    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
+    for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
+        $ch = curl_init("https://opengraph.githubassets.com/1/{$owner}/{$repo}");
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_TIMEOUT        => 15,
+            CURLOPT_USERAGENT      => 'ZeroCool-Portfolio',
+        ]);
 
-    if ($httpCode === 200 && !empty($data)) {
-        file_put_contents($cachePath, $data);
-        if ($isCli) echo "  [fetch] {$filename}\n";
-        return $filename;
+        $data     = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode === 200 && !empty($data)) {
+            file_put_contents($cachePath, $data);
+            if ($isCli) {
+                echo "  [fetch] {$filename}\n";
+            }
+            return $filename;
+        }
+
+        if ($httpCode === 429) {
+            if ($isCli) {
+                echo "  [429] {$filename} — rate limited, waiting {$retryDelay}s (attempt {$attempt}/{$maxRetries})\n";
+            }
+            if ($attempt < $maxRetries) {
+                sleep($retryDelay);
+                $retryDelay *= 2;
+            }
+            continue;
+        }
+
+        if ($isCli) {
+            fwrite(STDERR, "  [error] {$owner}/{$repo}: HTTP {$httpCode}\n");
+        }
+        return '';
     }
 
-    if ($isCli) fwrite(STDERR, "  [error] {$owner}/{$repo}: HTTP {$httpCode}\n");
+    if ($isCli) {
+        fwrite(STDERR, "  [error] {$owner}/{$repo}: gave up after {$maxRetries} attempts (rate limited)\n");
+    }
     return '';
 }
 


### PR DESCRIPTION
## 📑 Description
Introduce retry logic in the fetchOgImage function to handle 429 Too Many Requests HTTP responses with exponential backoff. Implement up to 3 retry attempts with an initial delay of 10 seconds, doubling the delay on each subsequent attempt. Enhance CLI logging for retries and failed download attempts for better monitoring and debugging.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add retry handling with exponential backoff to GitHub Open Graph image fetching to better tolerate rate limiting and improve CLI feedback.

Enhancements:
- Introduce up to three retry attempts with exponential backoff when fetching Open Graph images on HTTP 429 responses.
- Improve CLI output for cache hits, successful fetches, rate-limited retries, and terminal error conditions.