### PR TITLE
Update permissions for size-label workflow

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -6,7 +6,8 @@ on:
   
 jobs:
   size-label:
-    permissions: write-all
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## 📑 Description
Update permissions for size-label workflow

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

CI:
- Update the size-label GitHub Actions workflow to use pull-requests-only write permissions.